### PR TITLE
fix meta header to avoid error

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="viewport" content=" minimum-scale=1.0, maximum-scale=1.0, width=device-width; user-scalable=no">
+        <meta name="viewport" content=" minimum-scale=1.0, maximum-scale=1.0, width=device-width, user-scalable=no">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>{% block title %}{{ title|default('Simple CMS')|striptags }}{% endblock %}</title>
 


### PR DESCRIPTION
Viewport argument value "device-width;" for key "width" not recognized. Content ignored.

[solution](http://royaltutorials.com/viewport-argument-value-device-width-for-key-width-not-recognized-content-ignored/)
