### PR TITLE
make it possible to disable adding the locale pattern

### DIFF
--- a/Document/MultilangPage.php
+++ b/Document/MultilangPage.php
@@ -11,6 +11,23 @@ use Symfony\Component\Validator\Constraints as Assert;
 class MultilangPage extends Page
 {
     /**
+     * @PHPCRODM\Boolean()
+     */
+    protected $addLocalePattern;
+
+    /**
+     * Overwrite to be able to create route without pattern
+     *
+     * @param Boolean $addFormatPattern if to add ".{_format}" to the route pattern
+     *                                  also implicitly sets a default/require on "_format" to "html"
+     */
+    public function __construct($addFormatPattern = false, $addLocalePattern = true)
+    {
+        parent::__construct($addFormatPattern);
+        $this->addLocalePattern = $addLocalePattern;
+    }
+
+    /**
      * @Assert\NotBlank
      * @PHPCRODM\String(translated=true)
      */
@@ -41,6 +58,10 @@ class MultilangPage extends Page
      */
     public function getStaticPrefix()
     {
+        if (!$this->addLocalePattern) {
+            return parent::getStaticPrefix();
+        }
+
         $prefix = $this->getPrefix();
         $path = substr(parent::getPath(), strlen($prefix));
         $path = $prefix.'/{_locale}'.$path;


### PR DESCRIPTION
useful when f.e.switching locale via a different domain in combination with something like JMSI18NRoutingBundle
