### PR TITLE
Removed unwanted leftover 'use' throwing fatal.

### DIFF
--- a/Controller/PageAdminController.php
+++ b/Controller/PageAdminController.php
@@ -2,8 +2,6 @@
 
 namespace Symfony\Cmf\Bundle\SimpleCmsBundle\Controller;
 
-use Sonata\AdminBundle\Controller\CRUDController as Controller;
-
 class PageAdminController extends Controller
 {
 }


### PR DESCRIPTION
This was cousing fatal from time to time.

PHP Fatal error:  Class 'Sonata\AdminBundle\Controller\CRUDController' not found in [..] /vendor/symfony-cmf/simple-cms-bundle/Symfony/Cmf/Bundle/SimpleCmsBundle/Controller/PageAdminController.php on line 8
