### PR TITLE
load "body" instead of "content" in fixtures

### DIFF
--- a/DataFixtures/LoadCmsData.php
+++ b/DataFixtures/LoadCmsData.php
@@ -107,7 +107,7 @@ abstract class LoadCmsData extends ContainerAware implements FixtureInterface, O
                 } elseif (!isset($overview['label'])) {
                     $page->setLabel($overview['title']);
                 }
-                $page->setBody($overview['content']);
+                $page->setBody($overview['body']);
             }
 
             if (isset($overview['create_date'])) {


### PR DESCRIPTION
Fix a typo in fixture loading.
The website docs will need to be fixed, I'll do a PR right away
