### PR TITLE
Added label as translatable field

### DIFF
--- a/Document/MultilangPage.php
+++ b/Document/MultilangPage.php
@@ -39,6 +39,11 @@ class MultilangPage extends Page
     /**
      * @PHPCRODM\String(translated=true)
      */
+    protected $label;
+
+    /**
+     * @PHPCRODM\String(translated=true)
+     */
     public $body;
 
     /**


### PR DESCRIPTION
According to fixtures loading, "label" should be translatable. This makes sense to me, otherwise menu labels won't be translatable, but the routes and the content title and bodies they point to would
