### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1,<2.3-dev",
-        "symfony-cmf/routing-extra-bundle": ">=1.0.0-alpha3",
+        "symfony-cmf/routing-extra-bundle": "<1.1, >1.0.0-alpha3",
         "symfony-cmf/content-bundle": "1.0.*",
         "doctrine/phpcr-bundle": "1.0.*",
         "doctrine/phpcr-odm": "1.0.*"


### PR DESCRIPTION
I'm not sure if it's in the right bundle, but the alpha3 doesn't work with this bundle anymore due to the change in 
https://github.com/symfony-cmf/RoutingExtraBundle/commit/fe31d6014a223a4beea0eef64aac00d54da3ec32#L0L27
