### PR TITLE
Updated documentation to new URL (in README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ A trivial content management system based on the [Symfony Cmf](https://github.co
 
 ## Documentation
 
-http://symfony.com/doc/master/cmf/getting-started/simplecms.html
+http://symfony.com/doc/master/cmf/getting_started/simplecms.html


### PR DESCRIPTION
Documentation was old URL and 404'ing. I've updated that (old) URL to the new working URL.
