### PR TITLE
we may not blindly depend on a parameter from core that might not be set

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -6,7 +6,6 @@ use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
-use Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page;
 
 class PageAdmin extends Admin
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2013-08-31**: The multilang.locales configuration was added back as we do
+  need to care about locales and not depend on them when no locales are used.
+
 1.0.0-RC1
 ---------
 
@@ -39,7 +42,7 @@ Migration instructions:
        $CMFNS"\\Document\\Page" \
        $CMFNS"\\Doctrine\\Phpcr\\Page"
 ````
-         
+
 * **2013-08-04**: Changed name of Sonata route names / patterns - now /admin/cmf/simplecms/foo instead of /admin/bundle/simplecms/foo
 
 1.0.0-beta3

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -69,6 +69,17 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
+                ->arrayNode('multilang')
+                    ->fixXmlConfig('locale')
+                    ->children()
+                        ->arrayNode('locales')
+                            ->isRequired()
+                            ->requiresAtLeastOneElement()
+                            ->prototype('scalar')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/Resources/config/routing-phpcr.xml
+++ b/Resources/config/routing-phpcr.xml
@@ -26,7 +26,6 @@
             <argument/>
             <argument>null</argument>
             <call method="setManagerName"><argument>%cmf_simple_cms.persistence.phpcr.manager_name%</argument></call>
-            <call method="setLocales"><argument>%cmf_core.multilang.locales%</argument></call>
             <call method="setPrefix"><argument>%cmf_simple_cms.persistence.phpcr.basepath%</argument></call>
         </service>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

For the situation where no locales are configured, the current code gives an error about an undefined parameter.
