### PR TITLE
Check publish workflow dates towards the document we are testing

### DIFF
--- a/Tests/Functional/Doctrine/Phpcr/PageTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/PageTest.php
@@ -63,8 +63,8 @@ class PageTest extends BaseTestCase
         }
 
         // test publish start and end
-        $publishStartDate = $data['publishStartDate'];
-        $publishEndDate = $data['publishEndDate'];
+        $publishStartDate = $page->getPublishStartDate();
+        $publishEndDate = $page->getPublishEndDate();
 
         $this->assertInstanceOf('\DateTime', $publishStartDate);
         $this->assertInstanceOf('\DateTime', $publishEndDate);


### PR DESCRIPTION
This commit solves the issue https://github.com/symfony-cmf/symfony-cmf/issues/172 for SimpleCmsBundle.
The test seems to show another problem: fails because after the flush on line 48 the value of $data['publishStartDate'] and $data['publishEndDate'] is changed to the day before.
