### PR TITLE
remove unneeded hardcoded route name from admin

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -22,9 +22,6 @@ class PageAdmin extends Admin
 {
     protected $translationDomain = 'CmfSimpleCmsBundle';
 
-    protected $baseRouteName = 'cmf_simplecms_page';
-    protected $baseRoutePattern = '/cmf/simplecms/page';
-
     private $sortOrder = false;
 
     public function setSortOrder($sortOrder)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

These assignments are no longer needed. If we have them, an admin extending this class must overwrite the fields.
