### PR TITLE
delete deprecated fixture loader for tests

### DIFF
--- a/Tests/Resources/DataFixtures/Phpcr/LoadPageData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadPageData.php
@@ -14,18 +14,11 @@ namespace Symfony\Cmf\Bundle\SimpleCmsBundle\Tests\Resources\DataFixtures\Phpcr;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use PHPCR\Util\NodeHelper;
 use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
 
-class LoadPageData implements FixtureInterface, DependentFixtureInterface
+class LoadPageData implements FixtureInterface
 {
-    public function getDependencies()
-    {
-        return array(
-            'Symfony\Cmf\Component\Testing\DataFixtures\PHPCR\LoadBaseData',
-        );
-    }
-
     protected function getContent($filename)
     {
         return file_get_contents(__DIR__.'/content/'.$filename);
@@ -33,6 +26,7 @@ class LoadPageData implements FixtureInterface, DependentFixtureInterface
 
     public function load(ObjectManager $manager)
     {
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
         $root = $manager->find(null, '/test');
 
         $base = new Page();


### PR DESCRIPTION
removed deprecated classes as described in: symfony-cmf/symfony-cmf#191

But got an strange error in my local test, hope it just a local version problem. 
