### PR TITLE
Use config defined custom page while initialing homepage

### DIFF
--- a/Initializer/HomepageInitializer.php
+++ b/Initializer/HomepageInitializer.php
@@ -18,15 +18,16 @@ use Doctrine\Bundle\PHPCRBundle\Initializer\InitializerInterface;
 use Doctrine\ODM\PHPCR\DocumentManager;
 
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
-use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
 
 class HomepageInitializer implements InitializerInterface
 {
     private $basePath;
+    private $documentClass;
 
-    public function __construct($basePath)
+    public function __construct($basePath, $documentClass)
     {
         $this->basePath = $basePath;
+        $this->documentClass = $documentClass;
     }
 
     /**
@@ -43,7 +44,7 @@ class HomepageInitializer implements InitializerInterface
         $session = $dm->getPhpcrSession();
         NodeHelper::createPath($session, PathHelper::getParentPath($this->basePath));
 
-        $page = new Page();
+        $page = new $this->documentClass;
         $page->setId($this->basePath);
         $page->setLabel('Home');
         $page->setTitle('Homepage');

--- a/Resources/config/services-phpcr.xml
+++ b/Resources/config/services-phpcr.xml
@@ -13,6 +13,7 @@
             class="%cmf_simple_cms.initializer.class%"
         >
             <argument>%cmf_simple_cms.persistence.phpcr.basepath%</argument>
+            <argument>%cmf_simple_cms.persistence.phpcr.document.class%</argument>
             <tag name="doctrine_phpcr.initializer"/>
         </service>
     </services>


### PR DESCRIPTION
Hi,

This PR make the HomepageInitializer able to load the data with the custom configured Page object (with SEO configuration, etc...) instead of the default Page object.

Thanks,

Jérémy
