### PR TITLE
empty label means this page can not be displayed as menu item

### DIFF
--- a/Doctrine/Phpcr/Page.php
+++ b/Doctrine/Phpcr/Page.php
@@ -594,9 +594,11 @@ class Page extends Route implements
     }
 
     /**
-     * Whether to display the menu item for this.
+     * Whether a menu item for this page should be displayed if possible.
      *
      * @return boolean
+     *
+     * @see isDisplayableMenu
      */
     public function getDisplay()
     {
@@ -642,6 +644,17 @@ class Page extends Route implements
     }
 
     /**
+     * Whether this page can be displayed in the menu, meaning getDisplay is
+     * true and there is a non-empty label.
+     *
+     * @return boolean
+     */
+    public function isDisplayableMenu()
+    {
+        return $this->getDisplay() && $this->getLabel();
+    }
+
+    /**
      * Route method and Menu method - provides menu options merged with the
      * route options
      *
@@ -653,12 +666,12 @@ class Page extends Route implements
             'label' => $this->getLabel(),
             'attributes' => $this->getAttributes(),
             'childrenAttributes' => $this->getChildrenAttributes(),
-            'display' => $this->display,
-            'displayChildren' => $this->displayChildren,
+            'display' => $this->isDisplayableMenu(),
+            'displayChildren' => $this->getDisplayChildren(),
             'routeParameters' => array(),
             'routeAbsolute' => false,
-            'linkAttributes' => $this->linkAttributes,
-            'labelAttributes' => $this->labelAttributes,
+            'linkAttributes' => $this->getLinkAttributes(),
+            'labelAttributes' => $this->getLabelAttributes(),
             'content' => $this,
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #112 |
| License | MIT |
| Doc PR | not needed |

this was the best solution i found. we only display the menu node if the display option is true _and_ there is a label. this way `display` can default to true and the user can unset it to hide the menu, or edit the label and it starts appearing.

the only wtf would be when he adds a label and had set display to false previously. but whatever, that really is an edge case.
