### PR TITLE
Fix Typo NS declaration, Fatal local tests

### DIFF
--- a/Tests/Unit/DependencyInjection/XmlSchemaTest.php
+++ b/Tests/Unit/DependencyInjection/XmlSchemaTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\DependencyInjection;
+namespace Symfony\Cmf\Bundle\SimpleCmsBundle\Tests\Unit\DependencyInjection;
 
 use Symfony\Cmf\Component\Testing\Unit\XmlSchemaTestCase;
 


### PR DESCRIPTION
Running locally suite tests result in a fatal.
```php
PHP Fatal error:  Cannot redeclare class Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\DependencyInjection\XmlSchemaTest in /path/project/vendor/symfony-cmf/simple-cms-bundle/Tests/Unit/DependencyInjection/XmlSchemaTest.php on line 39
```