### PR TITLE
PHPDoc inheritance on Page object

### DIFF
--- a/Doctrine/Phpcr/Page.php
+++ b/Doctrine/Phpcr/Page.php
@@ -167,7 +167,7 @@ class Page extends Route implements
     }
 
     /**
-     * @return NodeInterface
+     * {@inheritDoc}
      */
     public function getNode()
     {


### PR DESCRIPTION
The getNode() method on the Page object should inherit the method documentation from the NodeInterface.

I haven't changed the annotations - but isn't it also:

```php
/**
 * {@inheritdoc}
 */
```

Rather than:

```php
/**
 * {@inheritDoc}
 */
```

The first is the example used on the phpDocumentor website and I'd imagine the change in case might cause some IDE's issues even if it is acceptable.