### PR TITLE
Fix route basepaths and CmfRoutingBundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ before_install:
   
 install: composer update $COMPOSER_FLAGS --prefer-dist
 
-before_script: vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
-
 script: phpunit --coverage-text
 
 notifications:

--- a/CmfSimpleCmsBundle.php
+++ b/CmfSimpleCmsBundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SimpleCmsBundle;
 
+use Symfony\Cmf\Bundle\SimpleCmsBundle\DependencyInjection\Compiler\AppendRouteBasepathPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappingsPass;
@@ -20,6 +21,8 @@ class CmfSimpleCmsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        $container->addCompilerPass(new AppendRouteBasepathPass());
 
         if ($container->hasExtension('jms_di_extra')) {
             $container->getExtension('jms_di_extra')->blackListControllerFile(__DIR__ . '/Controller/PageAdminController.php');

--- a/DependencyInjection/CmfSimpleCmsExtension.php
+++ b/DependencyInjection/CmfSimpleCmsExtension.php
@@ -50,11 +50,7 @@ class CmfSimpleCmsExtension extends Extension implements PrependExtensionInterfa
                 'enabled' => true,
             )
         );
-        if (isset($config['persistence']['phpcr']['basepath'])
-            && '/cms/simple' != $config['persistence']['phpcr']['basepath']
-        ) {
-            $prependConfig['dynamic']['persistence']['phpcr']['route_basepaths'] = array($config['persistence']['phpcr']['basepath']);
-        }
+
         $container->prependExtensionConfig('cmf_routing', $prependConfig);
     }
 

--- a/DependencyInjection/Compiler/AppendRouteBasepathPass.php
+++ b/DependencyInjection/Compiler/AppendRouteBasepathPass.php
@@ -17,7 +17,8 @@ class AppendRouteBasepathPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths')) {
+        if (!$container->hasParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths')
+            || !$container->hasParameter('cmf_simple_cms.persistence.phpcr.basepath')) {
             return;
         }
 

--- a/DependencyInjection/Compiler/AppendRouteBasepathPass.php
+++ b/DependencyInjection/Compiler/AppendRouteBasepathPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SimpleCmsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Appends the basepath for the SimpleCms to the RoutingBundle route basepaths.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class AppendRouteBasepathPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths')) {
+            return;
+        }
+
+        $routeBasepaths = $container->getParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths');
+        $routeBasepaths[] = $container->getParameter('cmf_simple_cms.persistence.phpcr.basepath');
+
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array_unique($routeBasepaths));
+    }
+}

--- a/Tests/Resources/DataFixtures/Phpcr/LoadPageData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadPageData.php
@@ -25,15 +25,7 @@ class LoadPageData implements FixtureInterface
 
     public function load(ObjectManager $manager)
     {
-        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
-        $root = $manager->find(null, '/test');
-
-        $base = new Page();
-        $base->setName('page');
-        $base->setTitle('Simple Cms');
-        $base->setLabel('Simple Cms');
-        $base->setParent($root);
-        $manager->persist($base);
+        $base = $manager->find(null, '/test/page');
 
         $page = new Page();
         $page->setName('homepage');

--- a/Tests/Resources/app/config/cmf_simple_cms.xml
+++ b/Tests/Resources/app/config/cmf_simple_cms.xml
@@ -3,9 +3,7 @@
 
     <config xmlns="http://cmf.symfony.com/schema/dic/simplecms">
         <persistence>
-            <phpcr
-                basepath="/test/page"
-                />
+            <phpcr basepath="/test/page"/>
         </persistence>
     </config>
 

--- a/Tests/Unit/DependencyInjection/Compiler/AppendRouteBasepathPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/AppendRouteBasepathPassTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SimpleCmsBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Cmf\Bundle\SimpleCmsBundle\DependencyInjection\Compiler\AppendRouteBasepathPass;
+
+class AppendRouteBasepathPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AppendRouteBasepathPass());
+    }
+
+    public function testAppendsSimpleCmsBasepathToCmfRouting()
+    {
+        $this->setParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array('/cms/routes'));
+        $this->setParameter('cmf_simple_cms.persistence.phpcr.basepath', '/cms/simple');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array('/cms/routes', '/cms/simple'));
+    }
+}

--- a/Tests/WebTest/Admin/PageAdminTest.php
+++ b/Tests/WebTest/Admin/PageAdminTest.php
@@ -20,7 +20,7 @@ class PageAdminTest extends BaseTestCase
     {
         $this->db('PHPCR')->loadFixtures(array(
             'Symfony\Cmf\Bundle\SimpleCmsBundle\Tests\Resources\DataFixtures\Phpcr\LoadPageData',
-        ));
+        ), true);
         $this->client = $this->createClient();
     }
 

--- a/Tests/WebTest/TestApp/HttpStatusCodeTest.php
+++ b/Tests/WebTest/TestApp/HttpStatusCodeTest.php
@@ -20,7 +20,8 @@ class HttpStatusCodeTest extends BaseTestCase
     {
         $this->db('PHPCR')->loadFixtures(array(
             'Symfony\Cmf\Bundle\SimpleCmsBundle\Tests\Resources\DataFixtures\Phpcr\LoadPageData',
-        ));
+        ), true);
+
         $this->client = $this->createClient();
     }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,12 @@
 
     <testsuites>
         <testsuite name="Symfony SimpleCmsBundle Test Suite">
+            <directory>./Tests/Unit</directory>
+        </testsuite>
+
+        <testsuite name="phpcr">
             <directory>./Tests</directory>
+            <exclude>./Tests/Unit</exclude>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Cmf\Component\Testing\Phpunit\DatabaseTestListener" />
+    </listeners>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory>.</directory>


### PR DESCRIPTION
Let's fix https://github.com/symfony-cmf/RoutingBundle/issues/290

Prepending isn't the solution here, as it means we override the default value (so enabling CmfRoutingBundle + CmfSimpleCmsBundle means only `/cms/simple` is configured as `route_basepath` instead of both `/cms/simple` and `/cms/routes`). Using a compiler pass, we can just append it to the route basepaths, exactly what we expect to happen.

Besides that, this PR now relies on the initializers to set up things correctly for the tests. As this was broken before, https://github.com/symfony-cmf/Testing/pull/114 should be merged to make these tests pass.

/cc @dbu